### PR TITLE
Update Rocket Pool min stake on stakingProviders.json

### DIFF
--- a/public/data/stakingProviders.json
+++ b/public/data/stakingProviders.json
@@ -1284,7 +1284,7 @@
         },
         "minStake": {
             "type": "eth",
-            "value": "10.4"
+            "value": "8"
         },
         "validatorKey": {
             "userValidator": true


### PR DESCRIPTION
Rocket Pool min stake changed to 8 ETH after Saturn 0 upgrade, seen that RPL is no longer required